### PR TITLE
Fixes for issue52

### DIFF
--- a/software/src/lib/serial_communication.c
+++ b/software/src/lib/serial_communication.c
@@ -291,7 +291,7 @@ static inline void print_command_from_history(const int8_t offset)
 
     // Copy command from history to current command buffer
     strncpy(cmd_buffer, cmd_history[cmd_history_index], CMD_BUFFER_SIZE);
-    cmd_buffer_index = strlen(cmd_buffer);
+    cmd_buffer_index = strlen(cmd_buffer) % CMD_BUFFER_SIZE;
 
     // Print out command and save command length for the next invocation
     usb_printf(cmd_buffer);

--- a/software/src/lib/usb.c
+++ b/software/src/lib/usb.c
@@ -186,11 +186,15 @@ void usb_main_task(void)
 
 void usb_printf(const char * const format, ...)
 {
+    // Prepare varargs parameter
     va_list ap;
-    char buffer[80] = "";
-
     va_start(ap, format);
-    vsprintf(buffer, format, ap);
+
+    // Format to buffer
+    char buffer[USB_PRINTF_MAX_LENGTH+1];
+    vsnprintf(buffer, sizeof(buffer), format, ap);
+
+    // Cleanup varargs
     va_end(ap);
 
     send_string(buffer);

--- a/software/src/lib/usb.h
+++ b/software/src/lib/usb.h
@@ -49,6 +49,10 @@
 /// \brief      Newline character sequence
 #define USB_NEWLINE                 "\r\n"
 
+/// \brief      Maximum length for strings printed with the `usb_printf()` function
+/// \see        usb_printf
+#define USB_PRINTF_MAX_LENGTH   100
+
 
 //---------------- data types ---------------//
 
@@ -78,7 +82,10 @@ void usb_main_task(void);
 /// \details    Unlike the "real" `printf`, this function does not return the number of written
 ///             bytes, because it can not be guaranteed that the bytes really got sent over the
 ///             bus. After writing the string to the send buffer, it is flushed.
+///             Also, strings formatted and printed with this function may not exceed a certain
+///             length, defined by #USB_PRINTF_MAX_LENGTH.
 /// \see        man 3 printf
+/// \see        USB_PRINTF_MAX_LENGTH
 void usb_printf(const char* format, ...);
 
 /// \brief      Sends the given character over USB


### PR DESCRIPTION
These changes should fix #52.

There was a pretty stupid buffer overflow in `usb_printf()` and another rogue pointer in the command history code.

/o\

Please test and merge this.